### PR TITLE
Safe

### DIFF
--- a/pkmn_inf_fusion/gui/__init__.py
+++ b/pkmn_inf_fusion/gui/__init__.py
@@ -1,3 +1,6 @@
 
+from .gui_util import *
+
 from .filter import Filter
+from .safe import Safe
 from .gui import GUI

--- a/pkmn_inf_fusion/gui/gui.py
+++ b/pkmn_inf_fusion/gui/gui.py
@@ -3,11 +3,11 @@ from tkinter import ttk, Tk, IntVar, StringVar, DoubleVar
 from typing import List, Tuple, Set, Optional, Dict, Iterable
 
 from pkmn_inf_fusion import EvolutionHelper, FusionRetriever, EvolutionLine, FusedEvoLine, util, Pokemon, FusedMon
+from pkmn_inf_fusion.gui import Filter, Safe, gui_util
 
 
 class GUI:
     __MON_SPLITER = ";"
-    __SAFE_PREFIX = "safe_"
     __DEFAULT_RATE = 50
     __SM_NAME = 0
     __SM_RATE = 1
@@ -105,6 +105,9 @@ class GUI:
         self.__tree_fusions = ttk.Treeview(frm, columns="fusions")
         self.__tree_fusions.grid(column=4, row=row+1, columnspan=2, rowspan=10)
         self.__tree_fusions.insert("", "end", "safe", text="Safe")
+        self.__safe = Safe(self.__retriever,
+                           insert=lambda id_, text: self.__tree_fusions.insert("safe", "end", id_, text=text),
+                           delete=self.__tree_fusions.delete, reset_details=self.__reset_details)
 
         # Pokemon details section
         row = 2
@@ -129,7 +132,8 @@ class GUI:
         add_detail("abilities", "Abilities: ", row+9)
 
         row = row+12
-        ttk.Button(frm, text="Save", command=self.__save_details, width=15).grid(column=6, row=row, columnspan=2)
+        self.__b_save = ttk.Button(frm, text="Save", command=self.__save_details, width=15)
+        self.__b_save.grid(column=6, row=row, columnspan=2)
         ttk.Button(frm, text="Swap", command=self.__swap_fusion, width=15).grid(column=6, row=row+1, columnspan=2)
 
         self.__tree_fusions.bind("<<TreeviewSelect>>", self.__set_details)
@@ -147,32 +151,14 @@ class GUI:
 
     def __set_details(self, event):
         encoded_id = self.__tree_fusions.focus()
-        pokemon = None
-        if encoded_id.startswith(GUI.__SAFE_PREFIX):
-            encoded_id = encoded_id[len(GUI.__SAFE_PREFIX):]    # remove safe prefix
-        try:
-            if "_" in encoded_id:
-                # we selected a concrete fusion
-                data = encoded_id.split("_")[1]  # first part is evolution line, second part is concrete
-                data = data.split("-")
-                head_id = int(data[0])
-                body_id = int(data[1])
-                pokemon = FusedMon(self.__retriever.get_pokemon(head_id), self.__retriever.get_pokemon(body_id))
-            elif "-" in encoded_id:
-                # we selected a fusion line -> showcase base mon since the concrete fusion can be seen by expanding
-                # skip prefix ("h" or "b") indicating for this case irrelevant fusion position
-                data = encoded_id[1:].split("-")  # split ids separated by "-"
-                mon_id = int(data[1])
-                pokemon = self.__retriever.get_pokemon(mon_id)
-            elif encoded_id in ["head", "body", "safe"]:
-                pass  # nothing to do
-            else:
-                # we selected a single pokemon
-                # skip prefix ("h" or "b") indicating for this case irrelevant fusion position
-                mon_id = int(encoded_id[1:])
-                pokemon = self.__retriever.get_pokemon(mon_id)
-        except:
-            print(f"Selection error for id: {encoded_id}")
+        parsed_ids = gui_util.parse_ids_from_tree(encoded_id)
+        if parsed_ids is None: return   # no valid pokemon id
+
+        head_id, body_id = parsed_ids
+        if body_id is None:
+            pokemon = self.__retriever.get_pokemon(head_id)
+        else:
+            pokemon = FusionRetriever.from_ids(self.__retriever, head_id, body_id)
 
         if pokemon is not None:
             self.__details["name"].set(pokemon.name)
@@ -193,47 +179,43 @@ class GUI:
                 ab_str += f"{ability}, "
             self.__details["abilities"].set(ab_str[:-2])    # remove trailing ", "
 
+            # set the text of the button correspondingly
+            if self.__safe.is_saved(parsed_ids):
+                self.__b_save.configure(text="Remove")
+            else:
+                self.__b_save.configure(text="Save")
+
+    def __reset_details(self):
+        self.__details["name"].set("?")
+        self.__details["bst"].set("")
+        self.__details["hp"].set("")
+        self.__details["atk"].set("")
+        self.__details["spatk"].set("")
+        self.__details["def"].set("")
+        self.__details["spdef"].set("")
+        self.__details["spd"].set("")
+
+        self.__details["type"].set("")
+        self.__details["abilities"].set("")
+
     def __save_details(self):
         if not self.__tree_is_resettable: return    # this means there are no head or body fusions
 
         encoded_id = self.__tree_fusions.focus()
-        if encoded_id.startswith(GUI.__SAFE_PREFIX): return     # don't save again
+        parsed_ids = gui_util.parse_ids_from_tree(encoded_id)
+        if parsed_ids is None: return   # no valid pokemon id
 
-        text = None
-        try:
-            if "_" in encoded_id:
-                # we selected a concrete fusion
-                data = encoded_id.split("_")[1]  # first part is evolution line, second part is concrete
-                data = data.split("-")
-                head_id = int(data[0])
-                body_id = int(data[1])
-                pokemon = FusedMon(self.__retriever.get_pokemon(head_id), self.__retriever.get_pokemon(body_id))
-
-                text = pokemon.name
-            elif "-" in encoded_id:
-                # we selected a fusion line -> showcase base mon since the concrete fusion can be seen by expanding
-                # skip prefix ("h" or "b") indicating for this case irrelevant fusion position
-                data = encoded_id[1:].split("-")  # split ids separated by "-"
-                mon_id = int(data[1])
-                text = self.__retriever.get_name(mon_id)
-            elif encoded_id in ["head", "body", "safe"]:
-                pass  # nothing to do
-            else:
-                # we selected a single pokemon
-                # skip prefix ("h" or "b") indicating for this case irrelevant fusion position
-                mon_id = int(encoded_id[1:])
-                text = self.__retriever.get_name(mon_id)
-        except:
-            print(f"Selection error for id: {encoded_id}")
-
-        if text is not None:
-            self.__tree_fusions.insert("safe", "end", f"{GUI.__SAFE_PREFIX}{encoded_id}", text=text)
+        head_id, body_id = parsed_ids
+        if self.__safe.is_saved(parsed_ids):
+            self.__safe.remove(head_id, body_id)
+        else:
+            self.__safe.save(head_id, body_id)
 
     def __swap_fusion(self):
         encoded_id = self.__tree_fusions.focus()
 
-        if encoded_id.startswith(GUI.__SAFE_PREFIX):
-            encoded_id = encoded_id[len(GUI.__SAFE_PREFIX):]    # remove safe prefix before swapping
+        if encoded_id.startswith(gui_util.safe_prefix()):
+            encoded_id = encoded_id[len(gui_util.safe_prefix()):]    # remove safe prefix before swapping
         try:
             if "_" in encoded_id:
                 # we selected a concrete fusion

--- a/pkmn_inf_fusion/gui/gui.py
+++ b/pkmn_inf_fusion/gui/gui.py
@@ -205,11 +205,7 @@ class GUI:
         parsed_ids = gui_util.parse_ids_from_tree(encoded_id)
         if parsed_ids is None: return   # no valid pokemon id
 
-        head_id, body_id = parsed_ids
-        if self.__safe.is_saved(parsed_ids):
-            self.__safe.remove(head_id, body_id)
-        else:
-            self.__safe.save(head_id, body_id)
+        self.__safe.invert_state(parsed_ids)
 
     def __swap_fusion(self):
         encoded_id = self.__tree_fusions.focus()

--- a/pkmn_inf_fusion/gui/gui_util.py
+++ b/pkmn_inf_fusion/gui/gui_util.py
@@ -1,0 +1,58 @@
+from typing import Optional, Tuple
+
+from pkmn_inf_fusion import util, FusedMon
+
+
+def safe_prefix() -> str:
+    return "safe_"
+
+
+def normalize_safe_id(id_: str) -> str:
+    """
+    Returns a version if id_ without safe_prefix() as prefix.
+    :param id_:
+    :return:
+    """
+    prefix = safe_prefix()
+    if id_.startswith(prefix):
+        id_ = id_[len(prefix):]
+    return id_
+
+
+def parse_ids_from_tree(encoded_id: str) -> Optional[Tuple[int, Optional[int]]]:
+    try:
+        # since pokemon are stored a bit different in safe, we need to first check this
+        if encoded_id.startswith(safe_prefix()):
+            encoded_id = int(normalize_safe_id(encoded_id))
+            if encoded_id > util.max_id():
+                return FusedMon.ids_from_fusion(encoded_id)
+            else:
+                return encoded_id, None
+        else:
+            if "_" in encoded_id:
+                # we selected a concrete fusion
+                data = encoded_id.split("_")[1]  # first part is evolution line, second part is concrete
+                data = data.split("-")
+                head_id = int(data[0])
+                body_id = int(data[1])
+
+                return head_id, body_id
+
+            elif "-" in encoded_id:
+                # we selected a fusion line -> showcase base mon since the concrete fusion can be seen by expanding
+                # skip prefix ("h" or "b") indicating for this case irrelevant fusion position
+                data = encoded_id[1:].split("-")  # split ids separated by "-"
+                mon_id = int(data[1])
+                return mon_id, None
+
+            elif encoded_id in ["head", "body", "safe"]:
+                pass  # nothing to do
+            else:
+                # we selected a single pokemon
+                # skip prefix ("h" or "b") indicating for this case irrelevant fusion position
+                mon_id = int(encoded_id[1:])
+                return mon_id, None
+    except:
+        print(f"Selection error for id: {encoded_id}")
+
+    return None

--- a/pkmn_inf_fusion/gui/safe.py
+++ b/pkmn_inf_fusion/gui/safe.py
@@ -5,7 +5,6 @@ from pkmn_inf_fusion.gui import safe_prefix, normalize_safe_id
 
 
 class Safe:
-
     def __init__(self, retriever: FusionRetriever, insert: Callable[[str, str], None], delete: Callable[[str], None],
                  reset_details: Callable[[], None]):
         self.__retriever = retriever
@@ -13,28 +12,19 @@ class Safe:
         self.__delete = delete
         self.__reset_details = reset_details
 
-        self.__saved_mons: Set[str] = set()
-
-    def _save(self, id_: str, text: str):
-        # we are finished if id_ is already saved
-        if id_ in self.__saved_mons: return
-
-        self.__saved_mons.add(id_)  # always save without prefix to avoid unintentional duplicates
-        self.__insert(f"{safe_prefix()}{id_}", text)
+        self.__saved_mons: Set[int] = set()
 
     def is_saved(self, id_: Union[str, int, Tuple[int, Optional[int]]]) -> bool:
-        if isinstance(id_, int):
-            id_ = str(id_)
+        if isinstance(id_, str):
+            id_ = int(normalize_safe_id(id_))  # we store the ids without the prefix so let's remove it
 
         elif isinstance(id_, Tuple):
             head_id, body_id = id_
             if body_id is None:
-                id_ = str(head_id)
+                id_ = head_id
             else:
-                id_ = str(FusedMon.calculate_id(head_id, body_id))
+                id_ = FusedMon.calculate_id(head_id, body_id)
 
-        else:
-            id_ = normalize_safe_id(id_)    # we store the ids without the prefix so let's remove it
         return id_ in self.__saved_mons
 
     def save(self, head_id: int, body_id: Optional[int]):
@@ -43,7 +33,10 @@ class Safe:
         else:
             pokemon = FusionRetriever.from_ids(self.__retriever, head_id, body_id)
 
-        self._save(str(pokemon.id), pokemon.name)
+        if pokemon.id in self.__saved_mons: return
+
+        self.__saved_mons.add(pokemon.id)  # always save without prefix to avoid unintentional duplicates
+        self.__insert(f"{safe_prefix()}{pokemon.id}", pokemon.name)
 
     def remove(self, head_id: int, body_id: Optional[int]):
         if body_id is None:
@@ -51,10 +44,31 @@ class Safe:
         else:
             pokemon = FusionRetriever.from_ids(self.__retriever, head_id, body_id)
 
-        id_ = str(pokemon.id)
-        if id_ in self.__saved_mons:
+        if pokemon.id in self.__saved_mons:
             # add the prefix because that's how it is saved in the TreeView
-            self.__delete(f"{safe_prefix()}{id_}")
+            self.__delete(f"{safe_prefix()}{pokemon.id}")
 
-            self.__saved_mons.remove(id_)
+            self.__saved_mons.remove(pokemon.id)
             self.__reset_details()
+
+    def invert_state(self, id_: Union[str, int, Tuple[int, Optional[int]]]):
+        """
+        Saves the mon corresponding to id_ if it's not already saved, otherwise removes it.
+
+        :param id_: id(s) of the mon we want to save or remove
+        :return:
+        """
+        if isinstance(id_, int):
+            head_id, body_id = id_, None
+
+        elif isinstance(id_, Tuple):
+            head_id, body_id = id_
+
+        else:
+            # we store the ids without the prefix so let's remove it
+            head_id, body_id = int(normalize_safe_id(id_)), None
+
+        if self.is_saved(id_):
+            self.remove(head_id, body_id)
+        else:
+            self.save(head_id, body_id)

--- a/pkmn_inf_fusion/gui/safe.py
+++ b/pkmn_inf_fusion/gui/safe.py
@@ -1,0 +1,60 @@
+from typing import Callable, Set, Optional, Tuple, Union
+
+from pkmn_inf_fusion import FusionRetriever, FusedMon
+from pkmn_inf_fusion.gui import safe_prefix, normalize_safe_id
+
+
+class Safe:
+
+    def __init__(self, retriever: FusionRetriever, insert: Callable[[str, str], None], delete: Callable[[str], None],
+                 reset_details: Callable[[], None]):
+        self.__retriever = retriever
+        self.__insert = insert
+        self.__delete = delete
+        self.__reset_details = reset_details
+
+        self.__saved_mons: Set[str] = set()
+
+    def _save(self, id_: str, text: str):
+        # we are finished if id_ is already saved
+        if id_ in self.__saved_mons: return
+
+        self.__saved_mons.add(id_)  # always save without prefix to avoid unintentional duplicates
+        self.__insert(f"{safe_prefix()}{id_}", text)
+
+    def is_saved(self, id_: Union[str, int, Tuple[int, Optional[int]]]) -> bool:
+        if isinstance(id_, int):
+            id_ = str(id_)
+
+        elif isinstance(id_, Tuple):
+            head_id, body_id = id_
+            if body_id is None:
+                id_ = str(head_id)
+            else:
+                id_ = str(FusedMon.calculate_id(head_id, body_id))
+
+        else:
+            id_ = normalize_safe_id(id_)    # we store the ids without the prefix so let's remove it
+        return id_ in self.__saved_mons
+
+    def save(self, head_id: int, body_id: Optional[int]):
+        if body_id is None:
+            pokemon = self.__retriever.get_pokemon(head_id)
+        else:
+            pokemon = FusionRetriever.from_ids(self.__retriever, head_id, body_id)
+
+        self._save(str(pokemon.id), pokemon.name)
+
+    def remove(self, head_id: int, body_id: Optional[int]):
+        if body_id is None:
+            pokemon = self.__retriever.get_pokemon(head_id)
+        else:
+            pokemon = FusionRetriever.from_ids(self.__retriever, head_id, body_id)
+
+        id_ = str(pokemon.id)
+        if id_ in self.__saved_mons:
+            # add the prefix because that's how it is saved in the TreeView
+            self.__delete(f"{safe_prefix()}{id_}")
+
+            self.__saved_mons.remove(id_)
+            self.__reset_details()

--- a/pkmn_inf_fusion/pokemon.py
+++ b/pkmn_inf_fusion/pokemon.py
@@ -1,6 +1,6 @@
 import json
 
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 
 from pkmn_inf_fusion import util
 
@@ -146,8 +146,27 @@ class Pokemon:
 
 
 class FusedMon(Pokemon):
+    @staticmethod
+    def calculate_id(head: int, body: int) -> int:
+        return head * util.max_id() + body
+
+    @staticmethod
+    def ids_from_fusion(fusion: int) -> Optional[Tuple[int, int]]:
+        """
+
+        :param fusion: id of the fusion we want to know the head and body of
+        :return: None for invalid ids, else (head_id, body_id)
+        """
+        # minimal id: head_id = 1, body_id = 1 -> fusion_id = 1 * max_id + 1
+        # maximal id: head_id = max_id, body_id = max_id -> fusion_id = max_id * max_id + max_id
+        if fusion <= util.max_id() or fusion > util.max_id() * util.max_id() + util.max_id():
+            return None  # invalid id
+        head_id = int(fusion / util.max_id())
+        body_id = fusion % util.max_id()
+        return head_id, body_id
+
     def __init__(self, head: Pokemon, body: Pokemon):
-        id_ = head.id * util.max_id() + body.id
+        id_ = FusedMon.calculate_id(head.id, body.id)
         name = head.name + body.name #f"?{head.name[:3]}{body.name[3:]}?"  # incorrect but doesn't matter
 
         hp = int((2 * head.hp + body.hp) / 3)


### PR DESCRIPTION
added Safe-class to handle the "safe"-section in the result-TreeView
- different TreeView-ids are not stored separately if they describe the same Pokemon (e.g., the main mon of head and body fusions is the same but has one TreeView-id for body and one for head; mons with different fusion lines can have fusions with the same other fusion line so the other end stage is also listed multiple times)
- already saved mons can be removed again individually
- details are reset after removing a mon